### PR TITLE
プルリク例（変更後）

### DIFF
--- a/pages/sample/index.vue
+++ b/pages/sample/index.vue
@@ -29,6 +29,7 @@
               </th>
               <td v-if="item.isInquiry" class="block w-full text-gray-700">
                 <textarea
+                  v-model="inquiry"
                   class="h-28 w-full mt-3.5 py-2 px-3 border-gray-300 rounded-md border-gray-300 focus:outline-none focus:ring-gray-300 focus:border-transparent"
                   placeholder="お問い合わせ内容"
                 ></textarea>
@@ -49,8 +50,17 @@
             </li>
             <li class="w-2/4 pl-3">
               <nuxt-link
+                v-if="inquiry"
                 to="/contact/confirm"
                 class="block w-full text-sm leading-9 text-center text-white rounded-md bg-pink"
+                @click="saveInquiry"
+                >確認ページへ</nuxt-link
+              >
+              <nuxt-link
+                v-else
+                to="/contact"
+                class="block w-full text-sm leading-9 text-center text-white rounded-md bg-pink-200 cursor-not-allowed"
+                @click="saveInquiry"
                 >確認ページへ</nuxt-link
               >
             </li>
@@ -62,25 +72,58 @@
 </template>
 
 <script setup>
-definePageMeta({
-  layout: "default-template",
-});
+import { ref, onMounted } from 'vue'
+import { useContactStore } from '~/store/contact'
 
-const contactInfo = [
-  { heading: "会社名", content: "test corporation" },
-  { heading: "お名前", content: "test name" },
-  { heading: "お名前(フリガナ)", content: "test name kana" },
-  { heading: "郵便番号", content: "〒1231234" },
-  { heading: "住所", content: "test address" },
-  { heading: "電話番号", content: "090-1234-1234" },
-  { heading: "メールアドレス", content: "test@test.com" },
-  {
-    heading: "お問い合わせ内容",
-    content: "",
-    isRequired: true,
-    isInquiry: true,
-  },
-];
+const store = useContactStore()
+
+definePageMeta({
+  layout: 'default-template',
+})
+
+const contactInfo = ref([])
+const inquiry = ref('')
+
+const userData = computed(() => {
+  return store.getUserData
+})
+
+const setContactInfo = () => {
+  contactInfo.value = [
+    { heading: '会社名', content: userData.value.user_entered_company_name },
+    {
+      heading: 'お名前',
+      content: `${userData.value.name_sei} ${userData.value.name_mei}`,
+    },
+    {
+      heading: 'お名前(フリガナ)',
+      content: `${userData.value.name_sei_kana} ${userData.value.name_mei_kana}`,
+    },
+    { heading: '郵便番号', content: `〒${userData.value.zip_code}` },
+    {
+      heading: '住所',
+      content: `${userData.value.address1} ${userData.value.address2}`,
+    },
+    { heading: '電話番号', content: userData.value.tel },
+    { heading: 'メールアドレス', content: userData.value.email },
+    {
+      heading: 'お問い合わせ内容',
+      content: '',
+      isRequired: true,
+      isInquiry: true,
+    },
+  ]
+}
+
+const saveInquiry = () => {
+  store.saveInquiry(inquiry.value)
+}
+
+onMounted(async () => {
+  await store.fetchUserData()
+  inquiry.value = store.getInquiry
+  setContactInfo()
+})
 </script>
 
 <style lang="scss" scoped>

--- a/store/contact.js
+++ b/store/contact.js
@@ -1,0 +1,49 @@
+import { defineStore } from "pinia";
+import axios from "axios";
+
+const baseUrl = import.meta.env.VITE_APP_API_BASE_URL;
+
+export const useContactStore = defineStore("loadContactStatus", {
+  state: () => ({
+    userData: {},
+    inquiry: "",
+  }),
+  actions: {
+    async fetchUserData() {
+      await axios.get(baseUrl + "/members").then((res) => {
+        this.userData = res.data.data;
+      });
+    },
+    saveInquiry(inquiryInfo) {
+      this.inquiry = inquiryInfo;
+    },
+    async sendMail(inquiryInfo) {
+      const url = `${baseUrl}/send_contact_mail`;
+      const params = {
+        mail_body: inquiryInfo,
+      };
+      // TODO: API未実装なので実装後に要確認
+      await axios
+        .post(url, params, {
+          headers: { "Content-Type": "application/json" },
+        })
+        .then((res) => {
+          console.log(res);
+          this.inquiry = "";
+        })
+        .catch(function (error) {
+          console.log(error);
+          throw new Error("send failed");
+        });
+    },
+  },
+
+  getters: {
+    getUserData(state) {
+      return state.userData;
+    },
+    getInquiry(state) {
+      return state.inquiry;
+    },
+  },
+});


### PR DESCRIPTION
# 実装内容
* 各項目はログインユーザーの会員情報取得するAPI（`GET: http://localhost:3000/members`）でセット
* 入力画面から確認画面へのデータ受け渡しはstore管理
* 確認画面の送信ボタン押下でメール送信API（`POST: http://localhost:3000/send_contact_mail`）にアクセス
* お問い合わせ内容が空の時はボタンが非活性になるバリデーション追加（確認画面でリロードした場合も空の値になるので同じようにバリデーション適用）

# 画面
* 入力→確認画面→送信失敗（アラート表示）
![4e957a3d85b2ee5ee66d48c66a49c7a3](https://user-images.githubusercontent.com/69967620/222990628-b381dc12-a4ef-404c-a449-e2e6179d1e96.gif)
* 確認画面でリロードするとボタンを非活性に
![7f14ef888b3cec6ff9d320cf792635ad](https://user-images.githubusercontent.com/69967620/222990631-437d134a-e110-4c47-9d41-3adb89e0ee96.gif)


 # 備考
メール送信APIはエラーが返ってきている（API未実装？）